### PR TITLE
Improve `isapprox` for ERA and LLA

### DIFF
--- a/test/satview_basics.jl
+++ b/test/satview_basics.jl
@@ -6,6 +6,11 @@ import Unitful: rad, °
     @test LLA(10°,10°,1000) ≈ LLA((10+100*eps())*°,10°,1000)
     @test LLA(90°,10°,1000) ≈ LLA(90°,130°,1000)
     @test LLA(40°,-180°,1000) ≈ LLA(40°,180°,1000)
+    @test LLA(0°, 0°, 0km) ≉ LLA(1.1e-5°, 0°, 0km)
+    @test LLA(0°, 0°, 0km) ≈ LLA(1e-5°, 0°, 0km)
+    @test LLA(0°, 0°, 0km) ≈ LLA(1e-5°, 1e-5°, 1e-6km)
+    @test LLA(0°, 0°, 0km) ≉ LLA(1e-5°, 1e-5°, 1.1e-6km)
+    @test_throws "atol" isapprox(LLA(0°, 0°, 0km),LLA(1e-5°, 1e-5°, 1e-6km); atol = 0.2)
     @test LLA(10°,10°,1000) !== LLA((10+100*eps())*°,10°,1000)
     @test isnan(LLA(1,1,NaN))
     
@@ -13,6 +18,11 @@ import Unitful: rad, °
     @test ERA(10°,1000,20°) == ERA(10°,1km,deg2rad(20)*rad)
     @test ERA(90°,1000,20°) ≈ ERA(90°,1km,deg2rad(90)*rad)
     @test isnan(ERA(1,1,NaN))
+    @test ERA(0°, 0km, 0°) ≉ ERA(1.1e-5°, 0km, 0°)
+    @test ERA(0°, 0km, 0°) ≈ ERA(1e-5°, 0km, 0°)
+    @test ERA(0°, 0km, 0°) ≈ ERA(1e-5°, 0km + 1e-6km, 0°)
+    @test ERA(0°, 0km, 0°) ≉ ERA(1e-5°, 0km + 1.1e-6km, 0°)
+    @test_throws "atol" isapprox(ERA(0°, 0km, 0°),ERA(1e-5°, 0km, 0°); atol = 0.2)
 
 
     # Geod Inverse

--- a/test/satview_struct.jl
+++ b/test/satview_struct.jl
@@ -20,7 +20,7 @@ import TelecomUtils: wgs84_ellipsoid
         ecef_ref = lla2ecef(lla_ref)
         ref_uv = get_pointing(sv, lla_ref)
         @test ref_uv ≈ get_pointing(sv, ecef_ref)
-        # @test get_lla(sv, ref_uv) ≈ lla_ref # This is broken because the resulting altitude difference is > √(eps)
+        @test get_lla(sv, ref_uv) ≈ lla_ref
         @test get_ecef(sv, ref_uv) ≈ ecef_ref     
     end
 


### PR DESCRIPTION
Fixes #22 
Now the default absolute tolerance for isapprox comparison of ERA and LLA objects is 1e-3 meters for distances and 1e-5 degrees for angles.
`atol` keyword arguments can't be used directly but separate kwargs have to be provided for ranges and angles