### PR TITLE
Generalize SatView

### DIFF
--- a/notebooks/satview_basics.jl
+++ b/notebooks/satview_basics.jl
@@ -433,9 +433,11 @@ md"""
   ╠═╡ =#
 
 # ╔═╡ 11938cb6-46b3-0002-96c0-ef6424d1d0db
+begin
 """
     geod_inverse(geod::Proj4.geod_geodesic, lonlat1::AbstractVector{Cdouble}, lonlat2::AbstractVector{Cdouble})
 	geod_inverse(geod::Proj4.geod_geodesic, lla1::LLA, lla2::LLA)
+	geod_inverse(em::EarthModel, lla1::LLA, lla2::LLA)
 Solve the inverse geodesic problem.
 
 # Args
@@ -465,11 +467,15 @@ function geod_inverse(geod::Proj4.geod_geodesic, lonlat1::AbstractVector{Cdouble
 	dist[], azi1[], azi2[]
 end
 
-# ╔═╡ 11938cb6-46b3-0003-96c0-ef6424d1d0db
+# Version with LLA inputs
 function geod_inverse(geod::Proj4.geod_geodesic, lla1::LLA, lla2::LLA)
 	lonlat1 = rad2deg.(SA_F64[lla1.lon,lla1.lat])
 	lonlat2 = rad2deg.(SA_F64[lla2.lon,lla2.lat])
 	geod_inverse(geod,lonlat1,lonlat2)
+end
+
+# Version with EarthModel as first input
+geod_inverse(em::EarthModel, lla1::LLA, lla2::LLA) = geod_inverse(em.geod, lla1, lla2)
 end
 
 # ╔═╡ 4c06d21c-ac14-4522-bf25-2e0a1ed2d6b9
@@ -481,6 +487,21 @@ begin
 	export LLA, ERA
 	export geod_inverse
 end
+
+# ╔═╡ 52fafdd7-503a-4665-a86f-ddd9fd6552ea
+# ╠═╡ skip_as_script = true
+#=╠═╡
+em = EarthModel()
+  ╠═╡ =#
+
+# ╔═╡ 87dec4f1-3842-4291-ad1c-1a384a197508
+#=╠═╡
+let
+	lla1 = LLA(1°, 2°, 0km)
+	lla2 = LLA(1°, 1°, 0km)
+	@benchmark geod_inverse($em, $lla1, $lla2)
+end
+  ╠═╡ =#
 
 # ╔═╡ 11938cb6-46b3-499b-96c0-ef6424d1d0db
 # ╠═╡ skip_as_script = true
@@ -1185,7 +1206,8 @@ version = "17.4.0+0"
 # ╠═7344190c-7989-4b55-b7be-357f7d6b7370
 # ╠═11938cb6-46b3-0001-96c0-ef6424d1d0db
 # ╠═11938cb6-46b3-0002-96c0-ef6424d1d0db
-# ╠═11938cb6-46b3-0003-96c0-ef6424d1d0db
+# ╠═52fafdd7-503a-4665-a86f-ddd9fd6552ea
+# ╠═87dec4f1-3842-4291-ad1c-1a384a197508
 # ╠═11938cb6-46b3-499b-96c0-ef6424d1d0db
 # ╠═d2c248b1-c48e-437b-a910-edcc59b4424f
 # ╠═7b306ed5-4bda-465d-abf2-4d07cb4642c1

--- a/notebooks/satview_struct.jl
+++ b/notebooks/satview_struct.jl
@@ -156,6 +156,10 @@ See also: [`change_position!`](@ref), [`get_range`](@ref), [`get_pointing`](@ref
 		"Face of the satellite used for the pointing computations"
 		face::Faces = PositiveZ
 	end
+	# Version allow to specify face as Symbol
+	function ReferenceView{T}(ecef, lla, earthmodel, R, rot_z, rot_y, rot_x, face::Union{Symbol, Int}) where T 
+		ReferenceView{T}(ecef, lla, earthmodel, R, rot_z, rot_y, rot_x, to_face(face))
+	end
 
 	const SatView = ReferenceView{:Satellite}
 	const UserView = ReferenceView{:User}
@@ -388,9 +392,6 @@ let
 	@test WNDfromECEF(rv.ecef, rv.R', em.ellipsoid)(ref_ecef) ≈ SA_F64[-√(100e3^2/2),0,√(100e3^2/2)]
 end
   ╠═╡ =#
-
-# ╔═╡ c2fdc43c-3279-47af-8cd5-bb57a58db574
-
 
 # ╔═╡ 84769564-8ba8-46f5-b494-b0689d9abd65
 # ╠═╡ skip_as_script = true
@@ -1825,7 +1826,6 @@ version = "17.4.0+0"
 # ╟─5c1d0beb-c00c-40a8-b255-c887be99e706
 # ╠═f127481d-c60e-43d0-ab9f-4d4f35984015
 # ╠═3a745709-8f5b-4f22-848a-2f9754ab27d8
-# ╠═c2fdc43c-3279-47af-8cd5-bb57a58db574
 # ╠═84769564-8ba8-46f5-b494-b0689d9abd65
 # ╠═0cde0a71-7f27-4290-88cd-2cccf627926b
 # ╠═bd62bdd6-4de4-449c-b5f1-fb1b4f695cda

--- a/notebooks/satview_struct.jl
+++ b/notebooks/satview_struct.jl
@@ -875,6 +875,7 @@ function get_era(uv::UserView, target::Union{LLA, Point3D, ReferenceView}; face 
 	_R = isnothing(R) ? inv(uv.R * face_rotation(face)) : R 
 	ERAfromECEF(uv.ecef, _R, uv.ellipsoid)(ecef)
 end
+get_era(sv::SatView, args...; kwargs...) = error("The first argument to `get_era` must be of type `UserView`.")
 end
 
 # ╔═╡ ee657a11-c976-4128-8bb4-2336a5ecd319

--- a/notebooks/satview_struct.jl
+++ b/notebooks/satview_struct.jl
@@ -88,9 +88,10 @@ md"""
 end
 
 # ╔═╡ e1a755fc-8164-4a94-8bff-494f8d95d2f2
-to_face(n::Int) = Faces(n)
+
 
 # ╔═╡ 9e8f0786-1daa-4b9e-9172-fc0767582c7e
+begin
 function to_face(s::Symbol)
 	s === :PositiveX && return PositiveX
 	s === :PositiveY && return PositiveY
@@ -99,6 +100,9 @@ function to_face(s::Symbol)
 	s === :NegativeY && return NegativeY
 	s === :NegativeZ && return NegativeZ
 	error("Unrecognized")
+end
+to_face(n::Int) = Faces(n)
+to_face(face::Faces) = face
 end
 
 # ╔═╡ 93222642-f2a6-4de7-8c92-21c96ef009a4
@@ -359,6 +363,14 @@ md"""
 """
 
 # ╔═╡ f127481d-c60e-43d0-ab9f-4d4f35984015
+"""
+	change_attitude!(rv::ReferenceView; rot_z = 0.0, rot_y = 0.0, rot_x = 0.0)
+Modify the attitude (local CRS orientation) of `rv` by recomputing its internal rotation matrix as a product of the default location based one and the attitude rotation based on `rot_z`, `rot_y` and `rot_x`.
+
+See [`crs_rotation`](@ref) for details on how the attitude rotation matrix is defined and computed.
+
+See also [`ReferenceView`](ref), [`change_position!`](@ref), [`change_Reference_face!`](@ref)
+"""
 function change_attitude!(rv::ReferenceView; rot_z = 0.0, rot_y = 0.0, rot_x = 0.0)
 	(;ecef, lla) = rv
 	change_position!(rv, ecef, lla ;rot_z, rot_y, rot_x)
@@ -390,6 +402,38 @@ let
 	# 45 degrees around the Z and 45 degrees around the Y axis means that the ref point should be at 45 degrees between the -X and +Z
 	change_attitude!(rv; rot_z = deg2rad(45), rot_y = deg2rad(45))
 	@test WNDfromECEF(rv.ecef, rv.R', em.ellipsoid)(ref_ecef) ≈ SA_F64[-√(100e3^2/2),0,√(100e3^2/2)]
+end
+  ╠═╡ =#
+
+# ╔═╡ 851f1994-22f4-4347-b106-2fa3ea75ebf2
+md"""
+## Change Reference Face
+"""
+
+# ╔═╡ 74d39d15-8d6c-4fb8-8d04-18f32c393ad4
+"""
+	change_reference_face!(rv::ReferenceView, face)
+Modify the reference face that is used to compute the visibilities from object `rv`.
+The face can be specified using an instance of `TelecomUtils.Faces` (not exported), a Symbol or an Int as follows:   
+- TelecomUtils.PositiveX **or** :PositiveX **or** 1
+- TelecomUtils.PositiveY **or** :PositiveY **or** 2
+- TelecomUtils.PositiveZ  **or** :PositiveZ **or** 3
+- TelecomUtils.NegativeX **or** :NegativeX **or** -1
+- TelecomUtils.NegativeY **or** :NegativeY **or** -2
+- TelecomUtils.NegativeZ **or** :NegativeZ **or** -3
+
+See also [`ReferenceView`](ref), [`change_position!`](@ref), [`change_attitude!`](@ref)
+"""
+function change_reference_face!(rv::ReferenceView, face)
+	setfield!(rv, :face, to_face(face))
+	return rv
+end
+
+# ╔═╡ 8b68c7c2-5cbd-4edd-9739-0d2e8c7f5449
+#=╠═╡
+let
+	rv = SatView(LLA(0,0,500km), em)
+	change_reference_face!(rv, :NegativeZ)
 end
   ╠═╡ =#
 
@@ -1841,6 +1885,9 @@ version = "17.4.0+0"
 # ╟─5c1d0beb-c00c-40a8-b255-c887be99e706
 # ╠═f127481d-c60e-43d0-ab9f-4d4f35984015
 # ╠═3a745709-8f5b-4f22-848a-2f9754ab27d8
+# ╟─851f1994-22f4-4347-b106-2fa3ea75ebf2
+# ╠═74d39d15-8d6c-4fb8-8d04-18f32c393ad4
+# ╠═8b68c7c2-5cbd-4edd-9739-0d2e8c7f5449
 # ╠═84769564-8ba8-46f5-b494-b0689d9abd65
 # ╠═33e4c937-4443-4d97-a3ed-81479ede1e11
 # ╠═0cde0a71-7f27-4290-88cd-2cccf627926b

--- a/notebooks/satview_transformations.jl
+++ b/notebooks/satview_transformations.jl
@@ -825,7 +825,7 @@ begin
 		uv = SVector(xyz[1],xyz[2]) ./  r
 		
 		# Return both the uv coordinates and the distance to the target point
-		return uv, xyz
+		return uv, r
 	end
 	# Default version without range
 	(trans::UVfromECEF)(ecef::StaticVector{3}) = trans(ecef,ExtraOutput())[1]
@@ -1021,6 +1021,19 @@ let
 	@test !isnan(uv2lla((u * (1+eps()),0), h = 100e3)) # We should find a solution because we are looking at 100km above earth
 	@test isnan(uv2lla((u * (1-eps()),0), h = 700e3)) # We should not find a solution because we are looking at 100km above the satellite alitude and with an angle slightly lower than eoe scan, so the corresponding valid point in the pointing direction is located behind earth
 	@test !isnan(uv2lla((u * (1+eps()),0), h = 700e3)) # We should find a solution because we are pointing more than eoe_scan so the earth is not blocking the view of the corresponding point
+end
+  ╠═╡ =#
+
+# ╔═╡ 83a29fe9-ad7a-4e7d-ba05-e6b3ce45c0c3
+#=╠═╡
+let
+	sat_lla = LLA(0,0,600km)
+	uv2lla = LLAfromUV(sat_lla; ellipsoid = sp)
+	lla2uv = inv(uv2lla)
+	target_uv = SA_F64[0.1,0.1]
+	target_lla, r = uv2lla(target_uv, ExtraOutput())
+	uv2, r2 = lla2uv(target_lla, ExtraOutput())
+	@test uv2 ≈ target_uv && r2 ≈ r
 end
   ╠═╡ =#
 
@@ -1767,5 +1780,6 @@ version = "17.4.0+0"
 # ╠═cbafedbf-adea-4249-b681-fc2f4816ebb9
 # ╠═c4a101fc-b7d2-41cb-9252-9fbad7811957
 # ╠═84c178cb-72bb-4aae-8ce0-5284b7b4a58d
+# ╠═83a29fe9-ad7a-4e7d-ba05-e6b3ce45c0c3
 # ╟─00000000-0000-0000-0000-000000000001
 # ╟─00000000-0000-0000-0000-000000000002

--- a/notebooks/satview_transformations.jl
+++ b/notebooks/satview_transformations.jl
@@ -678,6 +678,9 @@ begin
 		# Find the coordinates in the West-North-Down CRS
 		wnd = trans.R * pdiff
 		
+		# If the target is behind (so D is negative), we assume that it's not visible
+		wnd[3] < 0 && return SA_F64[NaN,NaN], NaN
+		
 		# Find the slant range between the satellite and the point
 		r = norm(wnd)
 		
@@ -812,6 +815,16 @@ let
 		target_uv[3] == [1,0],
 		target_uv[4] == [0,-1],
 	])
+end
+  ╠═╡ =#
+
+# ╔═╡ cbafedbf-adea-4249-b681-fc2f4816ebb9
+#=╠═╡
+let
+	sat_lla = LLA(0°, 0°, 600km)
+	target_lla = LLA(0°, 0°, 610km)
+	target_uv =	UVfromLLA(sat_lla; ellipsoid=SphericalEllipsoid())(target_lla)
+	@test all(isnan.(target_uv))
 end
   ╠═╡ =#
 

--- a/notebooks/satview_transformations.jl
+++ b/notebooks/satview_transformations.jl
@@ -737,8 +737,8 @@ begin
 		# Normalize the xyz vector
 		uv = SVector(xyz[1],xyz[2]) ./  r
 		
-		# Return both the uv coordinates and the slant range
-		return uv, r
+		# Return both the uv coordinates and the full xyz coordinates of the target point in the reference CRS
+		return uv, xyz
 	end
 	# Default version without range
 	(trans::UVfromECEF)(ecef::StaticVector{3}) = trans(ecef,ExtraOutput())[1]
@@ -779,7 +779,7 @@ begin
 	
 	function (trans::UVfromLLA)(lla::LLA, ex::ExtraOutput)
 		ecef = ECEFfromLLA(trans.ellipsoid)(lla)
-		uv, r = UVfromECEF(trans.origin,trans.R,trans.ellipsoid)(ecef, ex)
+		uv, xyz = UVfromECEF(trans.origin,trans.R,trans.ellipsoid)(ecef, ex)
 	end
 	# Single output method
 	(trans::UVfromLLA)(lla::LLA) = trans(lla,ExtraOutput())[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using TelecomUtils
 using Test
+using StaticArrays
 
 @testset verbose=true "TelecomUtils.jl" begin
+    Base.isnan(v::StaticArray) = any(isnan, v)
     include("satview_basics.jl")
     include("satview_transformations.jl")
     include("satview_struct.jl")

--- a/test/satview_struct.jl
+++ b/test/satview_struct.jl
@@ -26,9 +26,9 @@ import TelecomUtils: wgs84_ellipsoid
 
     @testset "Get ERA" begin
         # We test that a non-visible point is NaN
-        @test get_era(sv, LLA(40°, -39°, 0)) |> isnan
+        @test get_era(UserView(LLA(40°, -39°, 0), em), sv) |> isnan
         # We test that a visible point is not NaN, and with the expected value
-        @test get_era(sv,LLA(0,0,500km)) ≈ ERA(90°, 200km, 0°)
+        @test get_era(UserView(LLA(0,0,500km), em), sv) ≈ ERA(90°, 200km, 0°)
     end
 
     @testset "Get Distance on Earth" begin
@@ -37,7 +37,7 @@ import TelecomUtils: wgs84_ellipsoid
         em = EarthModel(sp)
         sv = SatView(LLA(0,0,700km), em)
         target_dist = 2π*r / 360
-        @test get_distance_on_earth(sv, LLA(0°, 0°, 0), LLA(1°, 0°, 0)) ≈ target_dist
+        @test get_distance_on_earth(LLA(0°, 0°, 0), LLA(1°, 0°, 0); em) ≈ target_dist
     end
 
     @testset "Get Nadir Beam Diameter" begin

--- a/test/satview_struct.jl
+++ b/test/satview_struct.jl
@@ -1,5 +1,5 @@
 import Unitful: °, km
-import TelecomUtils: wgs84_ellipsoid
+import TelecomUtils: wgs84_ellipsoid, ExtraOutput
 
 @testset "Satview Struct" begin
     sp_ell = SphericalEllipsoid()
@@ -13,15 +13,23 @@ import TelecomUtils: wgs84_ellipsoid
     @testset "SatView Creation" begin
         @test SatView(sat_lla, em; face = :PositiveY).face === TelecomUtils.PositiveY
         @test SatView(sat_lla, em; face = -1).face === TelecomUtils.NegativeX
+        @test SatView(sat_lla, em; face = TelecomUtils.PositiveX).face === TelecomUtils.PositiveX
     end
 
     @testset "Get Range" begin
+        # 2D Pointing based
         @test get_range(sv, (0,0)) ≈ sat_lla.alt
         @test get_range(sv, (0,0); h= 1e3) ≈ sat_lla.alt - 1e3
+        @test get_range(sv, (0,0); face=:NegativeZ) |> isnan # Default altitude is 0m so there is no intersection from face -Z
+        @test get_range(sv, (0,0); h = sv.lla.alt + 100e3, face=:NegativeZ) ≈ 100e3 # When providing an altitude above the satellite, the intersection from -Z is found
+
+        # ECEF/LLA/ReferenceView based
         @test get_range(sv, SatView(LLA(0,0,600km), em)) ≈ 100e3 # 2 ReferenceViews
-        @test_throws "EarthModel" get_range(sv, SatView(LLA(0,0,500km), EarthModel())) # Different EarthModels
         @test get_range(sv, SatView(LLA(0,0,800km), em)) |> isnan # The target is above the satellite, so not visible from the reference face
         @test get_range(sv, SatView(LLA(0,0,800km), em); face = :NegativeZ) ≈ 100e3 # The target is above the satellite, so it's visible from -Z
+
+        # Throws with different earth models
+        @test_throws "EarthModel" get_range(sv, SatView(LLA(0,0,500km), EarthModel())) # Different EarthModels
     end
 
     @testset "Get Pointing/LLA/ECEF" begin
@@ -31,6 +39,44 @@ import TelecomUtils: wgs84_ellipsoid
         @test ref_uv ≈ get_pointing(sv, ecef_ref)
         @test get_lla(sv, ref_uv;h = lla_ref.alt) ≈ lla_ref
         @test get_ecef(sv, ref_uv;h = lla_ref.alt) ≈ ecef_ref     
+
+        above = LLA(sv.lla.lat,sv.lla.lon,sv.lla.alt + 100e3)
+        below = LLA(sv.lla.lat,sv.lla.lon,sv.lla.alt - 100e3)
+        @test isapprox(get_pointing(sv, below),SA_F64[0,0]; atol = 1e-10)
+        @test get_pointing(sv, above) |> isnan
+        @test isapprox(get_pointing(sv, above; face = :NegativeZ),SA_F64[0,0]; atol = 1e-10)
+        # We test the X and Y faces.
+        @test isapprox(get_pointing(sv, below; face = :PositiveX),SA_F64[-1,0]; atol = 1e-10)
+        @test isapprox(get_pointing(sv, below; face = :NegativeX),SA_F64[1,0]; atol = 1e-10)
+        @test isapprox(get_pointing(sv, below; face = :PositiveY),SA_F64[0,-1]; atol = 1e-10)
+        @test isapprox(get_pointing(sv, below; face = :NegativeY),SA_F64[0,1]; atol = 1e-10)
+
+        # Test a point with manually computed theta angle
+        R_e = em.ellipsoid.a
+        sin_ρ = R_e/(R_e + sv.lla.alt)
+        θ = asin(sin_ρ)
+        lat = acos(sin_ρ)
+        thetaphi = get_pointing(sv, LLA(lat - 1e-5, 0, 0); pointing_type = :thetaphi) # We need 1e-5 to allow for tolerance with earth intersection
+        @test isapprox(thetaphi, SA_F64[θ, π/2]; atol = 1e-5)
+
+        # Test extra output
+        _, xyz = get_pointing(sv, LLA(0,0,0), ExtraOutput())
+        @test isapprox(xyz, SA_F64[0,0,sv.lla.alt]; atol = 1e-10)
+        _, xyz = get_pointing(sv, LLA(0,0,0), ExtraOutput(); face = :NegativeZ)
+        @test isnan(xyz) # The point is behind the satellite reference face
+        _, xyz = get_pointing(sv, LLA(0,0,0), ExtraOutput(); face = :PositiveX)
+        @test isapprox(xyz, SA_F64[-sv.lla.alt, 0,0]; atol = 1e-10)
+
+        # Test error with different earthmodel
+        @test_throws "EarthModel" get_pointing(sv, SatView(LLA(0,0,500km), EarthModel())) # Different EarthModels
+
+        # Get ECEF
+        @test get_ecef(sv, (0,0)) ≈ lla2ecef(LLA(0,0,0))
+        @test get_ecef(sv, (0,0); face = :NegativeZ) |> isnan
+        @test get_ecef(sv, (-1,0); face = :PositiveX) ≈ lla2ecef(LLA(0,0,0))
+        @test get_ecef(sv, (1,0); face = :NegativeX) ≈ lla2ecef(LLA(0,0,0))
+        @test get_ecef(sv, (0,-1); face = :PositiveY) ≈ lla2ecef(LLA(0,0,0))
+        @test get_ecef(sv, (0,1); face = :NegativeY) ≈ lla2ecef(LLA(0,0,0))
     end
 
     @testset "Get ERA" begin
@@ -38,6 +84,8 @@ import TelecomUtils: wgs84_ellipsoid
         @test get_era(UserView(LLA(40°, -39°, 0), em), sv) |> isnan
         # We test that a visible point is not NaN, and with the expected value
         @test get_era(UserView(LLA(0,0,500km), em), sv) ≈ ERA(90°, 200km, 0°)
+        @test_throws "EarthModel" get_era(UserView(LLA(0,0,0), EarthModel()), sv)
+        @test_throws "UserView" get_era(sv, LLA(0,0,0))
     end
 
     @testset "Get Distance on Earth" begin
@@ -54,12 +102,5 @@ import TelecomUtils: wgs84_ellipsoid
         @test get_nadir_beam_diameter(SatView(LLA(90°,0°,735km), EarthModel()), 55) ≈ get_nadir_beam_diameter(SatView(LLA(0°,0°,735km), EarthModel()), 55)
         # Test that the wgs84 ellipsoid makes a difference in the beam diameter computation
         @test get_nadir_beam_diameter(SatView(LLA(90°,0°,735km), EarthModel(wgs84_ellipsoid)), 55) ≉ get_nadir_beam_diameter(SatView(LLA(0°,0°,735km), EarthModel(wgs84_ellipsoid)), 55)
-    end
-
-    @testset "Unique Earth Model" begin
-        rv1 = SatView(LLA(0,0,600km), EarthModel())
-        rv2 = SatView(LLA(0.1,0.1,600km), EarthModel())
-        # This should error because the two rvs are instantiated with different Earth Model
-        @test_throws "EarthModel" get_pointing(rv1, rv2)
     end
 end

--- a/test/satview_struct.jl
+++ b/test/satview_struct.jl
@@ -10,6 +10,11 @@ import TelecomUtils: wgs84_ellipsoid
 
     sv = SatView(sat_lla, em)
 
+    @testset "SatView Creation" begin
+        @test SatView(sat_lla, em; face = :PositiveY).face === TelecomUtils.PositiveY
+        @test SatView(sat_lla, em; face = -1).face === TelecomUtils.NegativeX
+    end
+
     @testset "Get Range" begin
         @test get_range(sv, (0,0)) ≈ sat_lla.alt
         @test get_range(sv, (0,0); h= 1e3) ≈ sat_lla.alt - 1e3
@@ -45,5 +50,12 @@ import TelecomUtils: wgs84_ellipsoid
         @test get_nadir_beam_diameter(SatView(LLA(90°,0°,735km), EarthModel()), 55) ≈ get_nadir_beam_diameter(SatView(LLA(0°,0°,735km), EarthModel()), 55)
         # Test that the wgs84 ellipsoid makes a difference in the beam diameter computation
         @test get_nadir_beam_diameter(SatView(LLA(90°,0°,735km), EarthModel(wgs84_ellipsoid)), 55) ≉ get_nadir_beam_diameter(SatView(LLA(0°,0°,735km), EarthModel(wgs84_ellipsoid)), 55)
+    end
+
+    @testset "Unique Earth Model" begin
+        rv1 = SatView(LLA(0,0,600km), EarthModel())
+        rv2 = SatView(LLA(0.1,0.1,600km), EarthModel())
+        # This should error because the two rvs are instantiated with different Earth Model
+        @test_throws "EarthModel" get_pointing(rv1, rv2)
     end
 end

--- a/test/satview_struct.jl
+++ b/test/satview_struct.jl
@@ -18,6 +18,10 @@ import TelecomUtils: wgs84_ellipsoid
     @testset "Get Range" begin
         @test get_range(sv, (0,0)) ≈ sat_lla.alt
         @test get_range(sv, (0,0); h= 1e3) ≈ sat_lla.alt - 1e3
+        @test get_range(sv, SatView(LLA(0,0,600km), em)) ≈ 100e3 # 2 ReferenceViews
+        @test_throws "EarthModel" get_range(sv, SatView(LLA(0,0,500km), EarthModel())) # Different EarthModels
+        @test get_range(sv, SatView(LLA(0,0,800km), em)) |> isnan # The target is above the satellite, so not visible from the reference face
+        @test get_range(sv, SatView(LLA(0,0,800km), em); face = :NegativeZ) ≈ 100e3 # The target is above the satellite, so it's visible from -Z
     end
 
     @testset "Get Pointing/LLA/ECEF" begin

--- a/test/satview_struct.jl
+++ b/test/satview_struct.jl
@@ -12,7 +12,7 @@ import TelecomUtils: wgs84_ellipsoid
 
     @testset "Get Range" begin
         @test get_range(sv, (0,0)) ≈ sat_lla.alt
-        @test get_range(sv, (0,0), 1e3) ≈ sat_lla.alt - 1e3
+        @test get_range(sv, (0,0); h= 1e3) ≈ sat_lla.alt - 1e3
     end
 
     @testset "Get Pointing/LLA/ECEF" begin

--- a/test/satview_transformations.jl
+++ b/test/satview_transformations.jl
@@ -1,7 +1,8 @@
 import Unitful: °, km
 using Rotations
 import LinearAlgebra: normalize
-import TelecomUtils: earth_intersection
+import TelecomUtils: earth_intersection, ExtraOutput
+using StaticArrays
 
 @testset "Satview Transformations" begin
     sp_ell = SphericalEllipsoid()
@@ -77,5 +78,13 @@ import TelecomUtils: earth_intersection
         @test !isnan(uv2lla((u * (1+eps()),0), h = 100e3)) # We should find a solution because we are looking at 100km above earth
         @test isnan(uv2lla((u * (1-eps()),0), h = 700e3)) # We should not find a solution because we are looking at 100km above the satellite alitude and with an angle slightly lower than eoe scan, so the corresponding valid point in the pointing direction is located behind earth
         @test !isnan(uv2lla((u * (1+eps()),0), h = 700e3)) # We should find a solution because we are pointing more than eoe_scan so the earth is not blocking the view of the corresponding point
+
+
+        lla2uv = inv(uv2lla)
+        target_uv = SA_F64[0.1,0.1]
+        target_lla, r = uv2lla(target_uv, ExtraOutput())
+        uv2, r2 = lla2uv(target_lla, ExtraOutput())
+        @test uv2 ≈ target_uv 
+        @test r2 ≈ r
     end
 end

--- a/test/satview_transformations.jl
+++ b/test/satview_transformations.jl
@@ -73,9 +73,9 @@ import TelecomUtils: earth_intersection
         uv2lla = LLAfromUV(sat_lla; ellipsoid = sp)
         @test !isnan(uv2lla((u * (1-eps()),0))) # We should find a solution because we are pointing slightly less than EoE
         @test isnan(uv2lla((u * (1+eps()),0))) # We should not find a solution because we are pointing slightly more than EoE
-        @test !isnan(uv2lla((u * (1-eps()),0), 100e3)) # We should find a solution because we are looking at 100km above earth
-        @test !isnan(uv2lla((u * (1+eps()),0), 100e3)) # We should find a solution because we are looking at 100km above earth
-        @test isnan(uv2lla((u * (1-eps()),0), 700e3)) # We should not find a solution because we are looking at 100km above the satellite alitude and with an angle slightly lower than eoe scan, so the corresponding valid point in the pointing direction is located behind earth
-        @test !isnan(uv2lla((u * (1+eps()),0), 700e3)) # We should find a solution because we are pointing more than eoe_scan so the earth is not blocking the view of the corresponding point
+        @test !isnan(uv2lla((u * (1-eps()),0), h = 100e3)) # We should find a solution because we are looking at 100km above earth
+        @test !isnan(uv2lla((u * (1+eps()),0), h = 100e3)) # We should find a solution because we are looking at 100km above earth
+        @test isnan(uv2lla((u * (1-eps()),0), h = 700e3)) # We should not find a solution because we are looking at 100km above the satellite alitude and with an angle slightly lower than eoe scan, so the corresponding valid point in the pointing direction is located behind earth
+        @test !isnan(uv2lla((u * (1+eps()),0), h = 700e3)) # We should find a solution because we are pointing more than eoe_scan so the earth is not blocking the view of the corresponding point
     end
 end

--- a/test/satview_transformations.jl
+++ b/test/satview_transformations.jl
@@ -46,5 +46,10 @@ import TelecomUtils: earth_intersection
         @test target_uv[2] == [0,1]
         @test target_uv[3] == [1,0]
         @test target_uv[4] == [0,-1]
+
+
+        # We now test that targets behind the reference direction are not visible (NaN)
+        target_uv = UVfromLLA(LLA(0,0,600km))(LLA(0,0,610km))
+        @test all(isnan.(target_uv))
     end
 end

--- a/test_notebook.jl
+++ b/test_notebook.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.16.2
+# v0.19.24
 
 using Markdown
 using InteractiveUtils
@@ -7,14 +7,12 @@ using InteractiveUtils
 # ╔═╡ 122d494e-326b-11ec-0e29-551537ccbc53
 begin
 	import Pkg
-	Pkg.activate(".")
+	Pkg.activate(Base.current_project(@__FILE__))
+	using Revise
 end
 
 # ╔═╡ 0350a012-0b7d-4f14-89e1-d01b860b2928
 begin
-	using Revise
-	using PlotlyBase
-	using PlutoUtils
 	using TelecomUtils
 end
 
@@ -24,15 +22,12 @@ p = generate_hex_lattice(1;M=10)
 # ╔═╡ 3f56bf85-5d42-4d2e-8d68-b2999ac507f9
 col = TelecomUtils.generate_colors(p)
 
-# ╔═╡ 4cf7dfc7-b846-48b4-a902-7c7cb21ee6cd
-scatter(p;marker = attr(
-	color = TelecomUtils.generate_colors(p,4),
-	colorscale = "Jet",
-),mode = "markers") |> Plot
+# ╔═╡ 5e26311c-3ffa-45ae-ba66-5728ddd18aa9
+UserView(LLA(0,0,100km), EarthModel())
 
 # ╔═╡ Cell order:
 # ╠═122d494e-326b-11ec-0e29-551537ccbc53
 # ╠═0350a012-0b7d-4f14-89e1-d01b860b2928
 # ╠═07fbb59d-cb6c-4066-878d-130ba1951ee1
 # ╠═3f56bf85-5d42-4d2e-8d68-b2999ac507f9
-# ╠═4cf7dfc7-b846-48b4-a902-7c7cb21ee6cd
+# ╠═5e26311c-3ffa-45ae-ba66-5728ddd18aa9


### PR DESCRIPTION
The purpose of this pull request is to generalize the SatView struct to allow modelling the specific satellite orientation and reference face to use when computing visibilities and pointing angles.

The new expanded structure is called `ReferenceView{T}` where T is a Symbol. For the moment just two kinds are supported:
- `const SatView = ReferenceView{:Satellite}`
- `const UserView = ReferenceView{:User}`

These two different structures are designed to represent a Satellite and a User respectively. The two share exactly the same fields, and the only difference is that the default local CRS (prior to any orientation change) is WND (+Z axis towards nadir) for SatView and ENU (+Z Axis towards zenith) for UserView

This PR basically adds the following functionalities to `SatView` (also applicable for the new `UserView`):

- Possibility to specify a rotation of the satellite body w.r.t. to the default reference local CRS either during initialization, when calling `change_position!` or with the new function `change_attitude!`. The rotation is specified by the three new fields `rot_z`, `rot_y`, and `rot_y` and is applied by performing an [_intrinsic_ Tait-Bryan z-y'-x'' rotation](https://en.wikipedia.org/wiki/Euler_angles#Conventions)
- Allow to specify a reference face, with the 6 possible faces pointing in the directions of the local CRS axes (i.e. ±X, ±Y, ±Z), defaulting to +Z. This face is used by default when computing all the visibility and pointing angles from the SatView in question.\
After initialization, the reference face for an object can be changed using the new function `change_reference_face!`
The faces can be specified with either instances of the new `Enum` type `TelecomUtils.Faces`, as Symbols or with integer numbers as follows:
  - TelecomUtils.PositiveX **or** :PositiveX **or** 1
  - TelecomUtils.PositiveY **or** :PositiveY **or** 2
  - TelecomUtils.PositiveZ  **or** :PositiveZ **or** 3
  - TelecomUtils.NegativeX **or** :NegativeX **or** -1
  - TelecomUtils.NegativeY **or** :NegativeY **or** -2
  - TelecomUtils.NegativeZ **or** :NegativeZ **or** -3
- Enhance `get_range`, `get_era`, `get_lla`, `get_pointing`, and `get_ecef` to also accept specifying (as kwargs) a custom `face` and custom rotation matrix `R` to rotate (without accounting for translation) between ECEF coordinates to local CRS coordinates. `face` defaults to the reference one of the `ReferenceView` object specified during initialization, while `R` defaults to a rotation matrix generated composing the default rotation matrix based on satellite location, the rotation matrix to specify a non-default attitude (from the first point above) and the `face` selected with the respective kwarg.
- **The `get_era` function does not accept `SatView` anymore as first argument, but only `UserView`**. This is a breaking change but the `get_era` function is more meaningful with reference to a user, it was originally done from `SatView` because `UserView` did not exist
- The functions `get_range`, `get_pointing` and `get_era` allow specifying the target (2nd argument) also as another `ReferenceView`. In this case, the function checks internnaly that the `earthmodel` of both ReferenceView objects is pointing to the same structure, throwing an error otherwise.

