### PR TITLE
Add functions to compute visibility

### DIFF
--- a/notebooks/refview_struct.jl
+++ b/notebooks/refview_struct.jl
@@ -807,18 +807,10 @@ function get_visibility(rv::ReferenceView, lla_or_ecef::Union{LLA, Point3D}, eo:
 	else
 		lla_or_ecef
 	end	
-	# Check if the given ecef coordinate is visible from the satellite position or is obstructed from earth
-	pdiff = (ecef - rv.ecef)
-		
-	# Find the magnitude of the difference to compare with the intersection solutions
-	t = norm(pdiff)
-	normalized_pdiff = pdiff ./ t
-		
-	# Find the intersection points with the ellipsoid
-	t₁,t₂ = _intersection_solutions(normalized_pdiff,rv.ecef,rv.ellipsoid.a,rv.ellipsoid.b)
+	blocked, normalized_pdiff, _ = earth_blocking(rv.ecef,ecef, rv.ellipsoid.a,rv.ellipsoid.b, eo)
 
-	# If there is an intersection, we just return false
-	t₁ > 0 && t > t₁+1e-3 && return false, NaN, normalized_pdiff
+	# # If there is an intersection, we just return false
+	# t₁ > 0 && t > t₁+1e-3 && return false, NaN, normalized_pdiff
 
 	xyz = rv.R' * normalized_pdiff
 	θ = acos(dot(xyz, boresight_versor(boresight)))

--- a/notebooks/refview_struct.jl
+++ b/notebooks/refview_struct.jl
@@ -940,7 +940,10 @@ function get_visibility(rv::ReferenceView, lla_or_ecef::Union{LLA, Point3D}, eo:
 end
 	
 	# Double RefView method
-	get_visibility(rv1::ReferenceView, rv2::ReferenceView, args...; kwargs...) = get_visibility(rv1, rv2.ecef, args...; kwargs...)
+	function get_visibility(rv1::ReferenceView, rv2::ReferenceView, args...; kwargs...)
+		@assert rv1.earthmodel === rv2.earthmodel "When computing visibility between ReferenceView objects, the `EarthModel` they use internally must be the same"
+		get_visibility(rv1, rv2.ecef, args...; kwargs...)
+	end
 
 	# Single Output
 	get_visibility(rv1::ReferenceView, target; kwargs...) = get_visibility(rv1, target, ExtraOutput(); kwargs...)[1]

--- a/notebooks/refview_struct.jl
+++ b/notebooks/refview_struct.jl
@@ -905,7 +905,7 @@ end
 # ╔═╡ 387d2c76-1a08-441c-97fc-7b0a90a95c9a
 begin
 """
-	get_visibitiliy(rv::ReferenceView, target::Union{LLA, Point3D, ReferenceView}[, ::ExtraOutput]; boresight = rv.face, fov = 90°)
+	get_visibility(rv::ReferenceView, target::Union{LLA, Point3D, ReferenceView}[, ::ExtraOutput]; boresight = rv.face, fov = 90°)
 Returns `true` if `target` is visible from `rv` assuming an antenna boresight
 direction specified by `boresight` and a maximum Field of View from the
 boresight specified by `fov`.
@@ -1013,7 +1013,7 @@ md"""
 # ╔═╡ abd76e81-2464-4119-a9bf-6046805f8e57
 begin
 """
-	get_mutual_visibitiliy(rv1::ReferenceView, rv2::ReferenceView[, ::ExtraOutput]; boresights = (rv1.face, rv2.face), fov = (90°, 90°), short_circuit = true)
+	get_mutual_visibility(rv1::ReferenceView, rv2::ReferenceView[, ::ExtraOutput]; boresights = (rv1.face, rv2.face), fov = (90°, 90°), short_circuit = true)
 Similar to [`get_visibility`](@ref), returns `true` if `rv1` and `rv2` can see
 each other, assuming their antenna boresight directions to be specified by
 `boresights` and their maximum Field of View from the boresight to be specified

--- a/notebooks/refview_struct.jl
+++ b/notebooks/refview_struct.jl
@@ -1008,7 +1008,7 @@ md"""
 # ╔═╡ abd76e81-2464-4119-a9bf-6046805f8e57
 begin
 """
-	get_mutual_visibitiliy(rv1::ReferenceView, rv2::ReferenceView[, ::ExtraOutput]; boresights = (rv1.face, rv2.face), fov = (90°, 90°))
+	get_mutual_visibitiliy(rv1::ReferenceView, rv2::ReferenceView[, ::ExtraOutput]; boresights = (rv1.face, rv2.face), fov = (90°, 90°), short_circuit = true)
 Similar to [`get_visibility`](@ref), returns `true` if `rv1` and `rv2` can see
 each other, assuming their antenna boresight directions to be specified by
 `boresights` and their maximum Field of View from the boresight to be specified
@@ -1017,6 +1017,11 @@ by `fovs`.
 `boresights` and `fovs` are tuples containing the values of boresight and fov for the two
 ReferenceView objects. `boresights[1]` is used as reference boresight for `rv1` while
 `boresights[2]` is used for `rv2`. Similarly for `fovs`.
+
+The `short_circuit` kwarg defaults to true and permits to return early from the
+function to save time.  When `short_circuit == true`, if the fwd visibility is
+false, the function will directly return without computing the visibility angle
+on the return direction.
 
 Each `boresight` value inside the `boresights` kwarg can be specified either as a `face` (compatible with the
 input types specified in [`change_reference_face!`](@ref)) or as a 3D pointing
@@ -1037,11 +1042,11 @@ See also: [`get_pointing`](@ref), [`get_mutual_pointing`](@ref),
 [`get_lla`](@ref), [`get_ecef`](@ref), [`get_distance_on_earth`](@ref),
 [`get_visibility`](@ref).
 """
-function get_mutual_visibility(rv1::ReferenceView, rv2::ReferenceView, eo::ExtraOutput; boresights = (rv1.face, rv2.face), fovs = (90°, 90°))
+function get_mutual_visibility(rv1::ReferenceView, rv2::ReferenceView, eo::ExtraOutput; boresights = (rv1.face, rv2.face), fovs = (90°, 90°), short_circuit = true)
 	fwd = get_visibility(rv1, rv2, eo; boresight = boresights[1], fov = fovs[1])
 
 	# We compute the forward visibility, which also checks for earth intersection
-	fwd[1] || return false, (fwd, fwd)
+	fwd[1] || short_circuit && return false, (fwd, fwd)
 
 	normalized_pdiff = -fwd[3]
 

--- a/notebooks/refview_transformations.jl
+++ b/notebooks/refview_transformations.jl
@@ -1068,7 +1068,7 @@ function earth_blocking(ecef1, ecef2, a, b, ::ExtraOutput)
 	t₁,t₂ = _intersection_solutions(normalized_pdiff,ecef1,a,b)
 	# If there is an intersection, we return true and the normalized_pdiff
 	blocked = t₁ > 0 && t > t₁+1e-3
-	return blocked, normalized_pdiff, pdiff
+	return (;blocked, normalized_pdiff, pdiff)
 end
 
 # Single Output Version

--- a/notebooks/refview_transformations.jl
+++ b/notebooks/refview_transformations.jl
@@ -1050,6 +1050,31 @@ end
 @benchmark _intersection_solutions(SA_F64[100,0,0], SA_F64[-1,0,0], 10,10)
   ╠═╡ =#
 
+# ╔═╡ 0497740b-a441-41d9-8671-530d045a1712
+md"""
+### Earth Blocking
+"""
+
+# ╔═╡ c46c45e9-ef41-4015-93bb-6b71f5a7ffeb
+begin
+function earth_blocking(ecef1, ecef2, a, b, ::ExtraOutput)
+	@inline
+	# Check if the given ecef coordinate is visible from the satellite position or is obstructed from earth
+	pdiff = (ecef2 - ecef1)
+		
+	# Find the magnitude of the difference to compare with the intersection solutions
+	t = norm(pdiff)
+	normalized_pdiff = pdiff ./ t
+	t₁,t₂ = _intersection_solutions(normalized_pdiff,ecef1,a,b)
+	# If there is an intersection, we return true and the normalized_pdiff
+	blocked = t₁ > 0 && t > t₁+1e-3
+	return blocked, normalized_pdiff, pdiff
+end
+
+# Single Output Version
+earth_blocking(ecef1, ecef2, a, b) = earth_blocking(ecef1, ecef2, a, b, ExtraOutput())[1]
+end
+
 # ╔═╡ 7ab00d88-9f0c-4ad9-a735-6ef845055823
 # ╠═╡ skip_as_script = true
 #=╠═╡
@@ -1863,12 +1888,14 @@ version = "17.4.0+0"
 # ╠═1df46c22-c2ab-4384-9436-4b45e5603ed2
 # ╟─97e3be69-b480-482b-a1aa-5bf2ede10cbe
 # ╟─95704330-4d7b-44fd-b8c0-d1570812f619
-# ╠═2e788b78-e5e0-4f60-aa8c-ad4f203c982e
+# ╟─2e788b78-e5e0-4f60-aa8c-ad4f203c982e
 # ╠═4cea8d15-9bb9-455c-b8bf-10b8d9a2d4af
 # ╠═ea3e2a47-de2f-4383-8f01-e8fbebbdd605
 # ╠═d788faa8-df04-4a14-bef0-d76f85a9175e
 # ╠═2af585a1-05d0-4b5a-9ee6-15eabb40a27c
 # ╠═5cea5fed-1cee-41f3-bcdf-2d81e96c72d4
+# ╟─0497740b-a441-41d9-8671-530d045a1712
+# ╠═c46c45e9-ef41-4015-93bb-6b71f5a7ffeb
 # ╠═7ab00d88-9f0c-4ad9-a735-6ef845055823
 # ╠═f634d5d0-bb61-4bd6-9b1c-df75399de739
 # ╠═8b3f7041-ce2f-4d64-a135-9403eacd6385

--- a/test/refview_struct.jl
+++ b/test/refview_struct.jl
@@ -119,3 +119,50 @@ end
     # Test that the wgs84 ellipsoid makes a difference in the beam diameter computation
     @test get_nadir_beam_diameter(SatView(LLA(90°, 0°, 735km), EarthModel(wgs84_ellipsoid)), 55) ≉ get_nadir_beam_diameter(SatView(LLA(0°, 0°, 735km), EarthModel(wgs84_ellipsoid)), 55)
 end
+
+@testset "Get Visibility" begin
+    above = SatView(LLA(sv.lla.lat, sv.lla.lon, sv.lla.alt + 100e3), em)
+    below = SatView(LLA(sv.lla.lat, sv.lla.lon, sv.lla.alt - 100e3), em)
+    user_30_deg = get_ecef(sv, (30°, 0°); pointing_type = :thetaphi) |> x -> UserView(x, em)
+    sat_60_deg = get_ecef(sv, (60°, 0°); h = sv.lla.alt - 200e3, pointing_type = :thetaphi) |> x -> SatView(x, em; face = -3)
+    @test get_visibility(sv, below)
+    @test !get_visibility(sv, above)
+    @test get_visibility(sv, above; boresight = :NegativeZ)
+    @test get_visibility(sv, user_30_deg; fov = 30°)
+    @test !get_visibility(sv, user_30_deg; fov = 29.99°)
+    @test get_visibility(sv, sat_60_deg; fov = (60 + 1e-5)°)
+    @test !get_visibility(sv, sat_60_deg; fov = (60 - 1e-5)°)
+
+    # Test a point with manually computed theta angle
+    R_e = em.ellipsoid.a
+    sin_ρ = R_e / (R_e + sv.lla.alt)
+    θ = asin(sin_ρ)
+    lat = acos(sin_ρ)
+    visible, theta, _ = get_visibility(sv, LLA(lat - 1e-5, 0, 0), ExtraOutput()) # We need 1e-5 to allow for tolerance with earth intersection
+    @test isapprox(theta, θ; atol=1e-5)
+
+    # Test extra output
+    visible, θ, _ = get_visibility(sv, LLA(0, 0, 0), ExtraOutput())
+    @test abs(θ) < 1e-5
+    visible, θ, _ = get_visibility(sv, LLA(0, 180°, 0), ExtraOutput())
+    @test isnan(θ) # The target is blocked by earth
+    visible, θ, _ = get_visibility(sv, LLA(0, 0, 0), ExtraOutput(); boresight=:NegativeZ)
+    @test θ ≈ π && !visible # The point is behind the satellite reference face
+    visible, θ, _ = get_visibility(sv, LLA(0, 0, 0), ExtraOutput(); boresight=:PositiveX)
+    @test θ ≈ π/2 && visible
+
+    # Test error with different earthmodel
+    @test_throws "EarthModel" get_visibility(sv, SatView(LLA(0, 0, 500km), EarthModel())) # Different EarthModels
+end
+
+@testset "Get Mutual Visibitiliy" begin
+    sv1 = SatView(LLA(0, 0, 800km), em)
+    sv2 = SatView(LLA(0, 0, 1000km), em)
+    visible, (fwd, rtn) = get_mutual_visibility(sv1, sv2, ExtraOutput())
+    @test !visible && fwd === rtn # The reference face for sv1 is still nadir, so it doesn't see sv2. If we don't set short_circuit to false, fwd and rtn are equivalent as rtn is not computed
+    visible, ((fwd_visible, _), (rtn_visible, _)) = get_mutual_visibility(sv1, sv2, ExtraOutput(); short_circuit = false)
+    @test !visible && !fwd_visible && rtn_visible # The reference face for sv1 is still nadir, so it doesn't see sv2. but sv2 sees sv1
+
+    visible = get_mutual_visibility(sv1, sv2; boresights=(:NegativeZ, :PositiveZ))
+    @test visible
+end

--- a/test/refview_struct.jl
+++ b/test/refview_struct.jl
@@ -128,8 +128,8 @@ end
     @test get_visibility(sv, below)
     @test !get_visibility(sv, above)
     @test get_visibility(sv, above; boresight = :NegativeZ)
-    @test get_visibility(sv, user_30_deg; fov = 30°)
-    @test !get_visibility(sv, user_30_deg; fov = 29.99°)
+    @test get_visibility(sv, user_30_deg; fov = (30 + 1e-5)°)
+    @test !get_visibility(sv, user_30_deg; fov = (30 - 1e-5)°)
     @test get_visibility(sv, sat_60_deg; fov = (60 + 1e-5)°)
     @test !get_visibility(sv, sat_60_deg; fov = (60 - 1e-5)°)
 

--- a/test/refview_struct.jl
+++ b/test/refview_struct.jl
@@ -64,13 +64,13 @@ end
     @test isapprox(thetaphi, SA_F64[θ, π/2]; atol=1e-5)
 
     # Test extra output
-    _, xyz = get_pointing(sv, LLA(0, 0, 0), ExtraOutput())
-    @test isapprox(xyz, SA_F64[0, 0, sv.lla.alt]; atol=1e-10)
-    uv, xyz = get_pointing(sv, LLA(0, 180°, 0), ExtraOutput())
-    @test isnan(uv) && isnan(xyz) # The target is blocked by earth
-    uv, xyz = get_pointing(sv, LLA(0, 0, 0), ExtraOutput(); face=:NegativeZ)
-    @test isnan(uv) && isapprox(xyz, SA_F64[0, 0, -sv.lla.alt]; atol=1e-10) # The point is behind the satellite reference face
-    _, xyz = get_pointing(sv, LLA(0, 0, 0), ExtraOutput(); face=:PositiveX)
+    _, xyz, block_data = get_pointing(sv, LLA(0, 0, 0), ExtraOutput())
+    @test isapprox(xyz, SA_F64[0, 0, sv.lla.alt]; atol=1e-10) && !block_data.blocked
+    uv, xyz, block_data = get_pointing(sv, LLA(0, 180°, 0), ExtraOutput())
+    @test isnan(uv) && isnan(xyz) && block_data.blocked # The target is blocked by earth
+    uv, xyz, block_data = get_pointing(sv, LLA(0, 0, 0), ExtraOutput(); face=:NegativeZ)
+    @test isnan(uv) && isapprox(xyz, SA_F64[0, 0, -sv.lla.alt]; atol=1e-10) && !block_data.blocked # The point is behind the satellite reference face
+    _, xyz, block_data = get_pointing(sv, LLA(0, 0, 0), ExtraOutput(); face=:PositiveX)
     @test isapprox(xyz, SA_F64[-sv.lla.alt, 0, 0]; atol=1e-10)
 
     # Test error with different earthmodel

--- a/test/refview_struct.jl
+++ b/test/refview_struct.jl
@@ -66,8 +66,10 @@ end
     # Test extra output
     _, xyz = get_pointing(sv, LLA(0, 0, 0), ExtraOutput())
     @test isapprox(xyz, SA_F64[0, 0, sv.lla.alt]; atol=1e-10)
-    _, xyz = get_pointing(sv, LLA(0, 0, 0), ExtraOutput(); face=:NegativeZ)
-    @test isnan(xyz) # The point is behind the satellite reference face
+    uv, xyz = get_pointing(sv, LLA(0, 180°, 0), ExtraOutput())
+    @test isnan(uv) && isnan(xyz) # The target is blocked by earth
+    uv, xyz = get_pointing(sv, LLA(0, 0, 0), ExtraOutput(); face=:NegativeZ)
+    @test isnan(uv) && isapprox(xyz, SA_F64[0, 0, -sv.lla.alt]; atol=1e-10) # The point is behind the satellite reference face
     _, xyz = get_pointing(sv, LLA(0, 0, 0), ExtraOutput(); face=:PositiveX)
     @test isapprox(xyz, SA_F64[-sv.lla.alt, 0, 0]; atol=1e-10)
 


### PR DESCRIPTION
This PR adds `get_visibility` and `get_mutual_visibility` functions.

These functions are simpler version of `get_pointing` and `get_mutual_pointing`, which only look at the separation angle (θ) to assess visibility and execute slightly faster than the full `pointing` ones. (`get_mutual_visibility` is 30-50% faster than `get_mutual_pointing` depending on whether the pointing type is UV or ThetaPhi).

On top of that, the visibility functions allow for some additional flexibility as a completely custom boresight direction (w.r.t. the reference satellite orientation specified while initializing or changing attitude or position to a `ReferenceView` object) identified either with a `face` or with a custom 3D versor specifying the direction of the antenna on the local satellite CRS.

The signature for the first function is:
```julia
visible[, θ, ecef_pointing] = get_visibility(rv::ReferenceView, target::Union{LLA, Point3D, ReferenceView}[, ::ExtraOutput]; boresight = rv.face, fov = 90°)
```
where the `boresight` kwarg specifies the reference antenna direction from which the separation angle (θ) is computed, and `fov` represent the angle specifying the cone of the Field of View, expressed in radians unless given with `°` from Unitful like in the default value of the signature above.

The `boresight` kwarg can be provided either as a face, following the supported inputs for `face` as specified in https://github.com/disberd/TelecomUtils.jl/pull/24, or directly as a 3D vector identifying the pointing direction.
In case a Vector is given as input, the supported types are `Vector` of exactly 3 elements, `Tuple` of 3 numbers or `SVector{3}`.

The optional 2nd and 3rd outputs are only provided if the function is called with `ExtraOutput` as last argument.

The signature for the mutual version is
```julia
mutually_visible[, (fwd, rtn)] = get_mutual_visibility(rv1::ReferenceView, rv2::ReferenceView[, ::ExtraOutput]; boresights = (rv1.face, rv2.face), fov = (90°, 90°), short_circuit = true)
```

and the function return true if both forward and return direction have a positive visibility, taking into account the two boresight and fov for `rv1` and `rv2` specified with the `boresights` and `fovs` kwarg.

The mutual visibility function also provides a `short_circuit` kwarg that defaults to `true` and specifies whether the function should exit early (without computing the rtn direction visibility) if the fwd visibility is false.

The `short_circuit` kwarg has also been added to `get_mutual_pointing`.